### PR TITLE
Further styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
                 <span class="visuallyhidden">Add item to list</span>
             </button>
         </form>
-
         <div class="stave">
             <div class="measure"></div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -88,17 +88,25 @@ article > * {
 article > h2 {
     background-color: inherit;
     padding: 0.2rem 0.5rem 0.2rem 0.5rem;
+    overflow: scroll;
+}
+
+.form-container {
+    /* display: flex; */
+    /* text-align: center; */
+    position: relative;
 }
 
 form {
     border: black solid 2px;
-    /* display: flex;
-    flex-wrap: wrap; */
+    /* margin-left: auto;
+    margin-right: auto; */
     max-width: 80vw; 
-    /* max-width: 20rem; */
-    /* justify-content: space-between; */
+    
+    justify-content: space-between;
     padding-top: 0.5rem;
     padding-left: 0.5rem;
+    align-content: center;
 }
 
 form > input {

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,3 @@
-
-
 * {
     color: black;
     background-color: #FFDC9A;
@@ -15,8 +13,8 @@ button {
 }
 
 .bigger-horizontal-margins {
-    margin-left: 2rem;
-    margin-right: 2rem;
+    margin-left: 3rem;
+    margin-right: 3rem;
 }
 
 .hide {
@@ -28,10 +26,10 @@ button {
     color:#1D6036;
 }
 
-/* Credit: https://codepen.io/32bitkid/details/Ihciy */
+/* Credit: https://codepen.io/gvissing/pen/BKmmpJ */
 .stave {
     font-size: 0;
-    background-image: linear-gradient(180deg, #999 1px, transparent 8px, #999 1px, transparent 1px, transparent 8px, #999 8px, #999 9px, transparent 9px, transparent 16px, #999 16px, #999 17px, transparent 17px, transparent 24px, #999 24px, #999 25px, transparent 25px, transparent 32px, #999 32px, #999 33px, transparent 33px);
+    background-image: linear-gradient(180deg, #999 0, #999 1px, transparent 1px, transparent 8px, #999 8px, #999 9px, transparent 9px, transparent 16px, #999 16px, #999 17px, transparent 17px, transparent 24px, #999 24px, #999 25px, transparent 25px, transparent 32px, #999 32px, #999 33px, transparent 33px);
     background-size: 100% 80px;
 }
 
@@ -49,13 +47,6 @@ button {
     text-align: center;
 }
 
-form > button {
-    background-color: white;
-}
-form > button > * {
-    background-color: white;
-}
-
 /* Source: https://www.w3.org/WAI/tutorials/forms/labels/#note-on-hiding-elements */
 .visuallyhidden {
     border: 0;
@@ -68,41 +59,10 @@ form > button > * {
     width: 1px;
   }
 
-article {
-    display: flex;
-    flex-wrap: wrap;
-    max-width: 80vw;
-    align-items: baseline;
-    justify-content: space-around;
-    border: black solid 2px;
-    background-color: white;
-    padding: 0;
-}
-
-article > * {
-    /* border: solid black 2px; */
-    align-items: baseline;
-    margin-top: 1rem;
-}
-
-article > h2 {
-    background-color: inherit;
-    padding: 0.2rem 0.5rem 0.2rem 0.5rem;
-    overflow: scroll;
-}
-
-.form-container {
-    /* display: flex; */
-    /* text-align: center; */
-    position: relative;
-}
+/*input form and its contents*/
 
 form {
     border: black solid 2px;
-    /* margin-left: auto;
-    margin-right: auto; */
-    max-width: 80vw; 
-    
     justify-content: space-between;
     padding-top: 0.5rem;
     padding-left: 0.5rem;
@@ -122,11 +82,41 @@ form.close {
 form > button, form > button > * {
     background-color: #FFDC9A;
 }
-/* #item-1 > section:nth-child(5) > h2 */
+
+/*output and its contents*/
+
+article {
+    display: flex;
+    flex-wrap: wrap;
+    max-width: 100vw;
+    align-items: baseline;
+    justify-content: space-around;
+    border: black solid 2px;
+    background-color: white;
+    padding: 0;
+    box-shadow: 2px 1px 2px 1px;
+}
+
+article > * {
+    align-items: baseline;
+    margin-top: 1rem;
+    
+}
+
+article > h2 {
+    background-color: inherit;
+    padding: 0.2rem 0.5rem 0.2rem 0.5rem;
+    word-break: break-all;
+    max-width: 30vw;
+}
+
+
+
 .arrowBox {
     display:inline-block;
     font-size: larger;
     border: black solid 2px;
+    padding: 0.1rem;
 }
 
 input.checkboxes {

--- a/styles.css
+++ b/styles.css
@@ -31,7 +31,7 @@ button {
 /* Credit: https://codepen.io/32bitkid/details/Ihciy */
 .stave {
     font-size: 0;
-    background-image: linear-gradient(180deg, #999 0, #999 1px, transparent 1px, transparent 8px, #999 8px, #999 9px, transparent 9px, transparent 16px, #999 16px, #999 17px, transparent 17px, transparent 24px, #999 24px, #999 25px, transparent 25px, transparent 32px, #999 32px, #999 33px, transparent 33px);
+    background-image: linear-gradient(180deg, #999 1px, transparent 8px, #999 1px, transparent 1px, transparent 8px, #999 8px, #999 9px, transparent 9px, transparent 16px, #999 16px, #999 17px, transparent 17px, transparent 24px, #999 24px, #999 25px, transparent 25px, transparent 32px, #999 32px, #999 33px, transparent 33px);
     background-size: 100% 80px;
 }
 
@@ -114,11 +114,14 @@ form > input {
     font-size: 1.3em;
 }
 
-/* form > button {
-    border: solid black 1px;
-    padding: 0;
-    font-size: 1.2em;
-} */
+form.close {
+    border: none;
+    background-color: inherit;
+}
+
+form > button, form > button > * {
+    background-color: #FFDC9A;
+}
 /* #item-1 > section:nth-child(5) > h2 */
 .arrowBox {
     display:inline-block;


### PR DESCRIPTION
Still not 100% happy with the outcome here, but it had got to the point where I was mainly prodding at it and I think there are other priorities to work on. 

- I've used box-shadow to distinguish the notes a bit more from the note-taking part of the app. 
- Long words no longer disrupt the notes' layout too aggressively (at least up to the phone-screen size on Inspect). 
- It's not great at v wide sizes (things just sort of stretch out). If I have time, I can try to do some of the grid arrangement we discussed.
- staves lose lines at lower width

Do feel free to change anything you'd like! 